### PR TITLE
Build out state_config code and data

### DIFF
--- a/scripts/o3/o3_indicator.py
+++ b/scripts/o3/o3_indicator.py
@@ -10,7 +10,7 @@ Process summary:
 	- Read the tract-level preprocess output.
 	- Read each state's census block weights file from the shared pipeline inputs.
 	- Derive tract GEOIDs from block-group GEOIDs and join tract scores.
-	- Require scores for positive-population block groups.
+	- Generate scores for positive-population block groups.
 	- Set o3_score to null for zero-population block groups.
 	- Write per-state final_bg_scores.csv files and state summary logs.
 
@@ -63,68 +63,37 @@ def _resolve_scripts_dir() -> Path:
 
 
 SCRIPTS_DIR = _resolve_scripts_dir()
-SHARED_STATE_CONFIG_MODULE_PATH = SCRIPTS_DIR / 'shared' / 'state_config.py'
-SHARED_CONFIG_MODULE_PATH = SCRIPTS_DIR / 'shared' / 'shared_config.py'
-
-
-def _load_shared_state_config_symbols():
-	if not SHARED_STATE_CONFIG_MODULE_PATH.exists():
-		raise ImportError(f'Shared state_config.py not found: {SHARED_STATE_CONFIG_MODULE_PATH}')
-
-	module_spec = importlib.util.spec_from_file_location('shared_state_config_o3', SHARED_STATE_CONFIG_MODULE_PATH)
-	if module_spec is None or module_spec.loader is None:
-		raise ImportError(f'Unable to load module spec from {SHARED_STATE_CONFIG_MODULE_PATH}')
-
-	module = importlib.util.module_from_spec(module_spec)
-	sys.modules[module_spec.name] = module
-	module_spec.loader.exec_module(module)
-	return module.StateConfig, module.STATE_CONFIG_PATH, module.get_state_config
-
-
-def _load_shared_paths_config_symbols():
-	if not SHARED_CONFIG_MODULE_PATH.exists():
-		raise ImportError(f'Shared shared_config.py not found: {SHARED_CONFIG_MODULE_PATH}')
-
-	module_spec = importlib.util.spec_from_file_location('shared_config_o3', SHARED_CONFIG_MODULE_PATH)
-	if module_spec is None or module_spec.loader is None:
-		raise ImportError(f'Unable to load module spec from {SHARED_CONFIG_MODULE_PATH}')
-
-	module = importlib.util.module_from_spec(module_spec)
-	sys.modules[module_spec.name] = module
-	module_spec.loader.exec_module(module)
-	return module.get_shared_config, module.resolve_local_shared_root_path
-
+if str(SCRIPTS_DIR) not in sys.path:
+	sys.path.insert(0, str(SCRIPTS_DIR))
 
 try:
-	from ..shared.state_config import StateConfig, STATE_CONFIG_PATH, get_state_config
-except ImportError:
-	try:
-		from shared.state_config import StateConfig, STATE_CONFIG_PATH, get_state_config
-	except ImportError:
-		StateConfig, STATE_CONFIG_PATH, get_state_config = _load_shared_state_config_symbols()
+	from shared.state_config import StateConfig, get_state_config, get_state_config_list
+except Exception as exc:
+	raise RuntimeError(
+		'Failed to import shared.state_config. Ensure scripts/shared/state_config.py is present and '
+		'that the repository root (containing the scripts directory) is on PYTHONPATH.'
+	) from exc
 
 try:
-	from ..shared.shared_config import get_shared_config, resolve_local_shared_root_path
-except ImportError:
-	try:
-		from shared.shared_config import get_shared_config, resolve_local_shared_root_path
-	except ImportError:
-		get_shared_config, resolve_local_shared_root_path = _load_shared_paths_config_symbols()
+	from shared.shared_config import get_shared_config, resolve_local_shared_root_path
+except Exception as exc:
+	raise RuntimeError(
+		'Failed to import shared.shared_config. Ensure scripts/shared/shared_config.py is present and '
+		'that the repository root (containing the scripts directory) is on PYTHONPATH.'
+	) from exc
 
 
 @dataclass(frozen=True, slots=True)
 class Config:
 	storage_mode: str
 	state: str | None
-	tract_scores_path: str | None = None
-	census_block_weights_path: str | None = None
 	output_dir: str | None = None
 	final_bg_scores_filename: str = DEFAULT_FINAL_BG_SCORES_FILENAME
 
 
 @dataclass(frozen=True, slots=True)
 class ResolvedPaths:
-	state_config: Any
+	state_config: StateConfig
 	o3_root_path: str
 	shared_root_path: str
 	tract_scores_path: str
@@ -151,18 +120,6 @@ def get_config(argv=None) -> Config:
 		help='Optional two-letter state code to process a single state.',
 	)
 	parser.add_argument(
-		'--tract-scores-path',
-		dest='tract_scores_path',
-		default=defaults.tract_scores_path,
-		help='Optional explicit local path or S3 URI for the tract-level Ozone preprocessed CSV.',
-	)
-	parser.add_argument(
-		'--census-block-weights-path',
-		dest='census_block_weights_path',
-		default=defaults.census_block_weights_path,
-		help='Optional explicit local path or S3 URI for a state census block weights CSV.',
-	)
-	parser.add_argument(
 		'--output-dir',
 		dest='output_dir',
 		default=defaults.output_dir,
@@ -183,8 +140,6 @@ def get_config(argv=None) -> Config:
 	return Config(
 		storage_mode=args.storage_mode,
 		state=state,
-		tract_scores_path=args.tract_scores_path,
-		census_block_weights_path=args.census_block_weights_path,
 		output_dir=args.output_dir,
 		final_bg_scores_filename=args.final_bg_scores_filename,
 	)
@@ -224,34 +179,22 @@ def normalize_state_code(state_code: str) -> str:
 	return normalized_state_code
 
 
-def load_state_targets(selected_state: str | None) -> list[Any]:
-	"""Return the configured state targets, optionally filtered to one postal code."""
-	if not STATE_CONFIG_PATH.exists():
-		raise FileNotFoundError(f'State config file not found: {STATE_CONFIG_PATH}')
+# We can load one state or 'all' (as indicated by no argument). 
+# But note that each indicator needs to be aware of what its own 'all'
+# entails. In the case of Ozone, values are only available for the continental US,
+# so all is the 48 lower states plus DC.
+def load_state_targets(selected_state: str | None) -> list[StateConfig]:
+	logging.info('Loading state config(s) for selection: %s', selected_state or 'all')
+	state_list = []
 
-	with STATE_CONFIG_PATH.open('r', encoding='utf-8') as state_stream:
-		payload = json.load(state_stream)
-
-	if not isinstance(payload, dict):
-		raise RuntimeError(f'State config file must contain a JSON object: {STATE_CONFIG_PATH}')
-
-	# Filter configured states to CONUS entries first. For this indicator, "all"
-	# means only CONUS states. Also require that a requested single state be
-	# a CONUS state; otherwise raise to signal invalid selection.
-	conus_state_codes = sorted(
-		[code for code, cfg in payload.items() if isinstance(cfg, dict) and cfg.get('is_conus') is True]
-	)
-
-	if selected_state is not None:
-		if selected_state not in conus_state_codes:
-			raise RuntimeError(
-				f"Configured state '{selected_state}' was not found among CONUS states in {STATE_CONFIG_PATH.name}"
-			)
-		state_codes = [selected_state]
+	if selected_state:
+		state_config = get_state_config(selected_state)
+		state_list.append(state_config)
 	else:
-		state_codes = conus_state_codes
+		state_list = get_state_config_list('conus')
 
-	return [get_state_config(state_code) for state_code in state_codes]
+	logging.info('Loaded %d state configs for processing', len(state_list))
+	return state_list
 
 
 def is_s3_uri(path: str) -> bool:
@@ -307,28 +250,30 @@ def get_active_o3_root_path(storage_mode: str) -> str:
 
 def get_active_shared_root_path(storage_mode: str) -> str:
 	if storage_mode == 'local':
-		this_path = SCRIPTS_DIR/"shared"
-		return resolve_local_shared_root_path(this_path)
+		# 12 May 2026, not adopting Eric's change for this chunk of
+		# code. I don't think that hard-coding "shared" here is or should
+		# be needed. 
+		return resolve_local_shared_root_path(SCRIPTS_DIR)
 	if storage_mode == 'remote':
 		return get_shared_config().remote_root_path
 	raise ValueError(f'Unsupported storage mode: {storage_mode}')
 
 
-def resolve_paths(cfg: Config, state_config: Any) -> ResolvedPaths:
+def resolve_paths(cfg: Config, state_config: StateConfig) -> ResolvedPaths:
 	"""Resolve the tract input, shared block-weight input, and state output paths."""
 	o3_config = get_o3_config()
 	shared_cfg = get_shared_config()
 	o3_root_path = get_active_o3_root_path(cfg.storage_mode)
 	shared_root_path = get_active_shared_root_path(cfg.storage_mode)
 
-	tract_scores_path = cfg.tract_scores_path or join_root_and_relative_path(
+	tract_scores_path = join_root_and_relative_path(
 		o3_root_path,
 		o3_config.preprocessed_tract_output_relative_path,
 	)
 	census_block_weights_relative_path = shared_cfg.census_block_weights_relative_path_template.format(
 		postal=state_config.postal,
 	)
-	census_block_weights_path = cfg.census_block_weights_path or join_root_and_relative_path(
+	census_block_weights_path = join_root_and_relative_path(
 		shared_root_path,
 		census_block_weights_relative_path,
 	)
@@ -433,7 +378,7 @@ def log_resolved_paths(paths: ResolvedPaths, cfg: Config) -> None:
 
 def log_state_summary(
 	*,
-	state_config: Any,
+	state_config: StateConfig,
 	block_group_population: pd.DataFrame,
 	final_scores: pd.DataFrame,
 ) -> None:
@@ -463,7 +408,7 @@ def log_state_summary(
 	)
 
 
-def process_state(cfg: Config, state_config: Any, tract_scores: pd.DataFrame) -> None:
+def process_state(cfg: Config, state_config: StateConfig, tract_scores: pd.DataFrame) -> None:
 	"""Build and write one state's final Ozone block-group score file."""
 	paths = resolve_paths(cfg, state_config)
 	log_resolved_paths(paths, cfg)
@@ -491,7 +436,7 @@ def main(argv=None) -> int:
 	cfg = get_config(argv)
 	initialize_runtime_dependencies(cfg)
 	state_targets = load_state_targets(cfg.state)
-	tract_scores_path = cfg.tract_scores_path or join_root_and_relative_path(
+	tract_scores_path = join_root_and_relative_path(
 		get_active_o3_root_path(cfg.storage_mode),
 		get_o3_config().preprocessed_tract_output_relative_path,
 	)

--- a/scripts/pm25/pm25_indicator.py
+++ b/scripts/pm25/pm25_indicator.py
@@ -10,15 +10,19 @@ Process summary:
 	- Read the tract-level preprocess output.
 	- Read each state's census block weights file from the shared pipeline inputs.
 	- Derive tract GEOIDs from block-group GEOIDs and join tract scores.
-	- Require scores for positive-population block groups.
+	- Generate scores for positive-population block groups.
 	- Set pm25_score to null for zero-population block groups.
 	- Write per-state final_bg_scores.csv files and state summary logs.
 
 Runtime arguments:
-	- storage_mode
-		Required. Either local or remote.
-	- --state
+	- `storage_mode`
+		Required. Either `local` or `remote`.
+	- `--state`
 		Optional two-letter state filter. If omitted, process all configured states.
+	- `--output-dir`
+		Optional explicit local path or S3 URI for the state output directory.
+	- `--final-bg-scores-filename`
+		Optional override for the output filename (default: final_bg_scores.csv).
 
 Outputs:
 	- output/indicators/{postal}/final_bg_scores.csv under the active PM2.5 root.
@@ -53,78 +57,46 @@ BLOCK_GROUP_GEOID_COLUMN = 'block_group_geoid'
 BLOCK_GROUP_POP_COLUMN = 'block_group_pop'
 PM25_STORAGE_MODES = ('local', 'remote')
 
-
+# Find and then ensure the scripts directory is on sys.path so we can import shared modules
+# using the fixed relationship (scripts/shared) without dynamic module loading.
 def _resolve_scripts_dir() -> Path:
 	current_path = Path(__file__).resolve()
 	for parent in current_path.parents:
 		if parent.name == 'scripts':
 			return parent
 	raise RuntimeError(f'Unable to locate scripts directory from {current_path}')
-
-
 SCRIPTS_DIR = _resolve_scripts_dir()
-SHARED_STATE_CONFIG_MODULE_PATH = SCRIPTS_DIR / 'shared' / 'state_config.py'
-SHARED_CONFIG_MODULE_PATH = SCRIPTS_DIR / 'shared' / 'shared_config.py'
-
-
-def _load_shared_state_config_symbols():
-	if not SHARED_STATE_CONFIG_MODULE_PATH.exists():
-		raise ImportError(f'Shared state_config.py not found: {SHARED_STATE_CONFIG_MODULE_PATH}')
-
-	module_spec = importlib.util.spec_from_file_location('shared_state_config_pm25', SHARED_STATE_CONFIG_MODULE_PATH)
-	if module_spec is None or module_spec.loader is None:
-		raise ImportError(f'Unable to load module spec from {SHARED_STATE_CONFIG_MODULE_PATH}')
-
-	module = importlib.util.module_from_spec(module_spec)
-	sys.modules[module_spec.name] = module
-	module_spec.loader.exec_module(module)
-	return module.StateConfig, module.STATE_CONFIG_PATH, module.get_state_config
-
-
-def _load_shared_paths_config_symbols():
-	if not SHARED_CONFIG_MODULE_PATH.exists():
-		raise ImportError(f'Shared shared_config.py not found: {SHARED_CONFIG_MODULE_PATH}')
-
-	module_spec = importlib.util.spec_from_file_location('shared_config_pm25', SHARED_CONFIG_MODULE_PATH)
-	if module_spec is None or module_spec.loader is None:
-		raise ImportError(f'Unable to load module spec from {SHARED_CONFIG_MODULE_PATH}')
-
-	module = importlib.util.module_from_spec(module_spec)
-	sys.modules[module_spec.name] = module
-	module_spec.loader.exec_module(module)
-	return module.get_shared_config, module.resolve_local_shared_root_path
-
+if str(SCRIPTS_DIR) not in sys.path:
+	sys.path.insert(0, str(SCRIPTS_DIR))
 
 try:
-	from ..shared.state_config import StateConfig, STATE_CONFIG_PATH, get_state_config
-except ImportError:
-	try:
-		from shared.state_config import StateConfig, STATE_CONFIG_PATH, get_state_config
-	except ImportError:
-		StateConfig, STATE_CONFIG_PATH, get_state_config = _load_shared_state_config_symbols()
+	from shared.state_config import StateConfig, get_state_config, get_state_config_list
+except Exception as exc:
+	raise RuntimeError(
+		'Failed to import shared.state_config. Ensure scripts/shared/state_config.py is present and '
+		'that the repository root (containing the scripts directory) is on PYTHONPATH.'
+	) from exc
 
 try:
-	from ..shared.shared_config import get_shared_config, resolve_local_shared_root_path
-except ImportError:
-	try:
-		from shared.shared_config import get_shared_config, resolve_local_shared_root_path
-	except ImportError:
-		get_shared_config, resolve_local_shared_root_path = _load_shared_paths_config_symbols()
+	from shared.shared_config import get_shared_config, resolve_local_shared_root_path
+except Exception as exc:
+	raise RuntimeError(
+		'Failed to import shared.shared_config. Ensure scripts/shared/shared_config.py is present and '
+		'that the repository root (containing the scripts directory) is on PYTHONPATH.'
+	) from exc
 
 
 @dataclass(frozen=True, slots=True)
 class Config:
 	storage_mode: str
 	state: str | None
-	tract_scores_path: str | None = None
-	census_block_weights_path: str | None = None
 	output_dir: str | None = None
 	final_bg_scores_filename: str = DEFAULT_FINAL_BG_SCORES_FILENAME
 
 
 @dataclass(frozen=True, slots=True)
 class ResolvedPaths:
-	state_config: Any
+	state_config: StateConfig
 	pm25_root_path: str
 	shared_root_path: str
 	tract_scores_path: str
@@ -150,18 +122,8 @@ def get_config(argv=None) -> Config:
 		default=defaults.state,
 		help='Optional two-letter state code to process a single state.',
 	)
-	parser.add_argument(
-		'--tract-scores-path',
-		dest='tract_scores_path',
-		default=defaults.tract_scores_path,
-		help='Optional explicit local path or S3 URI for the tract-level PM2.5 preprocessed CSV.',
-	)
-	parser.add_argument(
-		'--census-block-weights-path',
-		dest='census_block_weights_path',
-		default=defaults.census_block_weights_path,
-		help='Optional explicit local path or S3 URI for a state census block weights CSV.',
-	)
+	# Removed optional overrides for tract and census block weights paths;
+	# these are resolved from the project config and shared config.
 	parser.add_argument(
 		'--output-dir',
 		dest='output_dir',
@@ -183,8 +145,6 @@ def get_config(argv=None) -> Config:
 	return Config(
 		storage_mode=args.storage_mode,
 		state=state,
-		tract_scores_path=args.tract_scores_path,
-		census_block_weights_path=args.census_block_weights_path,
 		output_dir=args.output_dir,
 		final_bg_scores_filename=args.final_bg_scores_filename,
 	)
@@ -223,25 +183,22 @@ def normalize_state_code(state_code: str) -> str:
 		raise RuntimeError(f"State code must be a two-letter postal abbreviation, got '{state_code}'")
 	return normalized_state_code
 
+# We can load one state or 'all' (as indicated by no argument). 
+# But note that each indicator needs to be aware of what its own 'all'
+# entails. In the case of PM2.5, values are only available for the continental US,
+# so all is the 48 lower states plus DC.
+def load_state_targets(selected_state: str | None) -> list[StateConfig]:
+	logging.info('Loading state config(s) for selection: %s', selected_state or 'all')
+	state_list = []
 
-def load_state_targets(selected_state: str | None) -> list[Any]:
-	"""Return the configured state targets, optionally filtered to one postal code."""
-	if not STATE_CONFIG_PATH.exists():
-		raise FileNotFoundError(f'State config file not found: {STATE_CONFIG_PATH}')
+	if selected_state:
+		state_config = get_state_config(selected_state)
+		state_list.append(state_config)
+	else:
+		state_list = get_state_config_list('conus')
 
-	with STATE_CONFIG_PATH.open('r', encoding='utf-8') as state_stream:
-		payload = json.load(state_stream)
-
-	if not isinstance(payload, dict):
-		raise RuntimeError(f'State config file must contain a JSON object: {STATE_CONFIG_PATH}')
-
-	state_codes = sorted(payload)
-	if selected_state is not None:
-		if selected_state not in state_codes:
-			raise RuntimeError(f"Configured state '{selected_state}' was not found in {STATE_CONFIG_PATH.name}")
-		state_codes = [selected_state]
-
-	return [get_state_config(state_code) for state_code in state_codes]
+	logging.info('Loaded %d state configs for processing', len(state_list))
+	return state_list
 
 
 def is_s3_uri(path: str) -> bool:
@@ -303,21 +260,21 @@ def get_active_shared_root_path(storage_mode: str) -> str:
 	raise ValueError(f'Unsupported storage mode: {storage_mode}')
 
 
-def resolve_paths(cfg: Config, state_config: Any) -> ResolvedPaths:
+def resolve_paths(cfg: Config, state_config: StateConfig) -> ResolvedPaths:
 	"""Resolve the tract input, shared block-weight input, and state output paths."""
 	pm25_config = get_pm25_config()
 	shared_cfg = get_shared_config()
 	pm25_root_path = get_active_pm25_root_path(cfg.storage_mode)
 	shared_root_path = get_active_shared_root_path(cfg.storage_mode)
 
-	tract_scores_path = cfg.tract_scores_path or join_root_and_relative_path(
+	tract_scores_path = join_root_and_relative_path(
 		pm25_root_path,
 		pm25_config.preprocessed_tract_output_relative_path,
 	)
 	census_block_weights_relative_path = shared_cfg.census_block_weights_relative_path_template.format(
 		postal=state_config.postal,
 	)
-	census_block_weights_path = cfg.census_block_weights_path or join_root_and_relative_path(
+	census_block_weights_path = join_root_and_relative_path(
 		shared_root_path,
 		census_block_weights_relative_path,
 	)
@@ -421,7 +378,7 @@ def log_resolved_paths(paths: ResolvedPaths, cfg: Config) -> None:
 
 def log_state_summary(
 	*,
-	state_config: Any,
+	state_config: StateConfig,
 	block_group_population: pd.DataFrame,
 	final_scores: pd.DataFrame,
 ) -> None:
@@ -451,7 +408,7 @@ def log_state_summary(
 	)
 
 
-def process_state(cfg: Config, state_config: Any, tract_scores: pd.DataFrame) -> None:
+def process_state(cfg: Config, state_config: StateConfig, tract_scores: pd.DataFrame) -> None:
 	"""Build and write one state's final PM2.5 block-group score file."""
 	paths = resolve_paths(cfg, state_config)
 	log_resolved_paths(paths, cfg)
@@ -479,7 +436,7 @@ def main(argv=None) -> int:
 	cfg = get_config(argv)
 	initialize_runtime_dependencies(cfg)
 	state_targets = load_state_targets(cfg.state)
-	tract_scores_path = cfg.tract_scores_path or join_root_and_relative_path(
+	tract_scores_path = join_root_and_relative_path(
 		get_active_pm25_root_path(cfg.storage_mode),
 		get_pm25_config().preprocessed_tract_output_relative_path,
 	)
@@ -493,7 +450,9 @@ def main(argv=None) -> int:
 	for state_config in state_targets:
 		process_state(cfg, state_config, prepared_tract_scores)
 
-	logging.info('Completed PM2.5 block-group indicator generation for %d states', len(state_targets))
+	msg = f'Completed PM2.5 block-group indicator generation for {len(state_targets)} state(s).'
+	logging.info(msg)
+	print(msg)
 	return 0
 
 

--- a/scripts/pm25/pm25_indicator.py
+++ b/scripts/pm25/pm25_indicator.py
@@ -122,8 +122,6 @@ def get_config(argv=None) -> Config:
 		default=defaults.state,
 		help='Optional two-letter state code to process a single state.',
 	)
-	# Removed optional overrides for tract and census block weights paths;
-	# these are resolved from the project config and shared config.
 	parser.add_argument(
 		'--output-dir',
 		dest='output_dir',
@@ -254,6 +252,9 @@ def get_active_pm25_root_path(storage_mode: str) -> str:
 
 def get_active_shared_root_path(storage_mode: str) -> str:
 	if storage_mode == 'local':
+		# 12 May 2026, not adopting Eric's change for this chunk of
+		# code. I don't think that hard-coding "shared" here is or should
+		# be needed. 
 		return resolve_local_shared_root_path(SCRIPTS_DIR)
 	if storage_mode == 'remote':
 		return get_shared_config().remote_root_path
@@ -450,7 +451,12 @@ def main(argv=None) -> int:
 	for state_config in state_targets:
 		process_state(cfg, state_config, prepared_tract_scores)
 
-	msg = f'Completed PM2.5 block-group indicator generation for {len(state_targets)} state(s).'
+	state_count = len(state_targets)
+	msg = f"Completed PM2.5 block-group indicator generation"
+	if state_count == 1:
+		msg += f" for {state_count} state: {state_targets[0].postal}"
+	else:
+		msg += f" for {state_count} states"
 	logging.info(msg)
 	print(msg)
 	return 0

--- a/scripts/shared/shared_config.json
+++ b/scripts/shared/shared_config.json
@@ -1,5 +1,5 @@
 {
-  "local_root_path": "pipeline/",
+  "local_root_path": "shared/pipeline/",
   "remote_root_path": "s3://pedp-data-preserved/ejscreen-data-processing/shared/pipeline/",
   "downloads_subtree_name": "downloads",
   "preprocessed_input_subtree_name": "preprocessed_input",

--- a/scripts/shared/state_config.json
+++ b/scripts/shared/state_config.json
@@ -414,5 +414,38 @@
     "type": "territory",
     "is_conus": false,
     "metric_crs": "+proj=aea +lat_1=8 +lat_2=18 +lat_0=3 +lon_0=-66 +x_0=0 +y_0=0 +datum=NAD83 +units=m +no_defs"
+  },
+
+  "AS": {
+    "fips": "60",
+    "postal": "AS",
+    "name": "American Samoa",
+    "metric_crs": "",
+    "type": "territory",
+    "is_conus": false
+  },
+  "GU": {
+    "fips": "66",
+    "postal": "GU",
+    "name": "Guam",
+    "metric_crs": "",
+    "type": "territory",
+    "is_conus": false
+  },
+  "MP": {
+    "fips": "69",
+    "postal": "MP",
+    "name": "Commonwealth of the Northern Mariana Islands",
+    "metric_crs": "",
+    "type": "territory",
+    "is_conus": false
+  },
+  "VI": {
+    "fips": "78",
+    "postal": "VI",
+    "name": "U.S. Virgin Islands",
+    "metric_crs": "",
+    "type": "territory",
+    "is_conus": false
   }
 }

--- a/scripts/shared/state_config.py
+++ b/scripts/shared/state_config.py
@@ -5,10 +5,24 @@ records keyed by two-letter postal code. It centralizes the canonical state
 identifiers used by client code, including FIPS code, postal abbreviation,
 display name, and the projected metric CRS to use for state-level processing.
 
-The loader fails fast when state codes are invalid, required fields are
-missing, or CRS definitions are not projected in meters. This gives downstream
-scripts a simple, consistent way to retrieve validated state metadata before
-performing distance calculations or writing state-specific outputs.
+The loader fails fast when parameter values are invalid.
+
+Public functions:
+- `get_state_config(state_code: str) -> StateConfig`:
+    Return a validated `StateConfig` for the given two-letter postal state code.
+    The `state_code` argument is normalized to upper-case; the function raises
+    `RuntimeError` if the code is not present in the config file, if required fields are
+    missing, or CRS definitions are not projected in meters. This gives downstream
+    scripts a simple, consistent way to retrieve validated state metadata before
+    performing distance calculations or writing state-specific outputs. 
+
+- `get_state_config_list(extent: str) -> list[StateConfig]`:
+    Return a list of `StateConfig` objects filtered by `extent`. Valid `extent`
+    values (case-insensitive) are: `CONUS`, `US-51`, `US-52`, `TERRITORIES`,
+    and `ALL`. The function raises `RuntimeError` for invalid `extent` values.
+    This function does not perform the per-entry field validation done by
+    `get_state_config`; it maps raw config entries into `StateConfig` objects.
+
 """
 
 from __future__ import annotations
@@ -137,3 +151,75 @@ def _require_nonempty_string(raw_state_config: dict[str, Any], field_name: str, 
         )
 
     return field_value.strip()
+
+
+def _make_sc(postal: str, raw: Any) -> StateConfig:
+    if not isinstance(raw, dict):
+        raw = {}
+    fips = raw.get('fips') or ''
+    postal_field = (raw.get('postal') or postal or '')
+    name = raw.get('name') or ''
+    metric_crs = raw.get('metric_crs') or DEFAULT_METRIC_CRS
+    return StateConfig(fips=fips, postal=postal_field, name=name, metric_crs=metric_crs)
+
+
+def get_state_config_list(extent: str) -> list[StateConfig]:
+    """Return a list of StateConfig entries filtered by `extent`.
+
+    extent (case-insensitive) must be one of:
+      - CONUS: 48 continental US states + DC (uses `is_conus` flag)
+      - US-51: all 50 states + DC
+      - US-52: all 50 states + DC + PR
+      - TERRITORIES: only territories (no states)
+      - ALL: all configured entries
+
+    This function does not perform the field-level validation that `get_state_config`
+    does; it simply maps raw JSON entries into `StateConfig` objects and returns
+    the list. Missing fields are filled with empty-string defaults (or
+    `DEFAULT_METRIC_CRS` for `metric_crs`).
+    """
+    if not isinstance(extent, str):
+        raise RuntimeError(f'extent must be a string, got {type(extent).__name__}')
+
+    key = extent.strip().upper()
+    valid = {'CONUS', 'US-51', 'US-52', 'TERRITORIES', 'ALL'}
+    if key not in valid:
+        raise RuntimeError(f"Invalid extent value '{extent}'. Must be one of: {', '.join(sorted(valid))}")
+
+    raw_state_configs = _load_state_configs()
+
+    results: list[StateConfig] = []
+
+    if key == 'ALL':
+        for postal, raw in raw_state_configs.items():
+            results.append(_make_sc(postal, raw))
+    elif key == 'TERRITORIES':
+        for postal, raw in raw_state_configs.items():
+            if isinstance(raw, dict) and str(raw.get('type', '')).lower() == 'territory':
+                results.append(_make_sc(postal, raw))
+    elif key == 'CONUS':
+        for postal, raw in raw_state_configs.items():
+            if isinstance(raw, dict) and raw.get('is_conus') is True:
+                results.append(_make_sc(postal, raw))
+    elif key in {'US-51', 'US-52'}:
+        for postal, raw in raw_state_configs.items():
+            if not isinstance(raw, dict):
+                continue
+            typ = str(raw.get('type', '')).lower()
+            postal_upper = str(raw.get('postal') or postal or '').upper()
+            # include all states
+            if typ == 'state':
+                results.append(_make_sc(postal, raw))
+                continue
+            # include DC
+            if postal_upper == 'DC':
+                results.append(_make_sc(postal, raw))
+                continue
+            # for US-52 include Puerto Rico (PR) explicitly; do not include other territories
+            if key == 'US-52' and postal_upper == 'PR':
+                results.append(_make_sc(postal, raw))
+    else:
+        # sure, this can't happen given validation above, but stuff happens . . .
+        raise RuntimeError(f"Unhandled extent value '{extent}'")
+
+    return results

--- a/tests/test_state_config_list.py
+++ b/tests/test_state_config_list.py
@@ -1,0 +1,43 @@
+"""Simple test for `get_state_config_list()` counts.
+
+This test loads the raw `state_config.json` and computes expected counts for
+the following extents: CONUS, US-51, US-52, TERRITORIES, ALL. It then calls
+`get_state_config_list()` (case-insensitive) and asserts the returned list
+length matches the computed expectation. The test is intentionally small and
+does not require external services.
+"""
+from pathlib import Path
+import sys
+import json
+
+# Ensure the scripts directory is importable like the runtime.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = REPO_ROOT / 'scripts'
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from shared import state_config as sc
+
+# AG-supplied expected counts
+EXPECTED_COUNTS: dict[str, int | None] = {
+    'CONUS': 49,
+    'US-51': 51,
+    'US-52': 52,
+    'TERRITORIES': 5,
+    'ALL': 56
+}
+
+
+def test_get_state_config_list_counts():
+    cfg_path = SCRIPTS_DIR / 'shared' / 'state_config.json'
+    for extent in ('CONUS', 'US-51', 'US-52', 'TERRITORIES', 'ALL'):
+        result = sc.get_state_config_list(extent)
+        expected = EXPECTED_COUNTS.get(extent)
+        print(f'{extent}: expected={expected}, got={len(result)}')
+        if expected is not None:
+            assert len(result) == expected
+        assert all(isinstance(s, sc.StateConfig) for s in result)
+
+
+if __name__ == '__main__':
+    test_get_state_config_list_counts()
+    print('OK')


### PR DESCRIPTION

 The primary change here is to add an accessor method, get_state_config_list to state_config.py, 
 which returns a list of StateConfig objects filtered by a specified "extent" value.
All scripts should start using this method or the one-state get_state_config method rather than directly accessing the raw config data.

I added a unit test for the new method to verify the returned counts are what *I* expect them to be. The expectations are:
```
EXPECTED_COUNTS: dict[str, int | None] = {
    'CONUS': 49,  # lower 48 + DC
    'US-51': 51,  # all states + DC
    'US-52': 52,  # US-51 + PR
    'TERRITORIES': 5,  # the five non-state territories
    'ALL': 56  # all entries
}
```

I added the four remaining territories to the state_config.json file; these may cause backward compatiblity problems for any code that is reading that file directly. I will search out and update that code next and convert it to calling get_state_config_list.

I changed the 'all' code in pm25_indicator.py to use the new get_state_config_list method, passing the correct 'conus' extent value.
and also:
- simplified some of the module loading code
- deleted two runtime arguments and configuration entries that I had used before we had a well-defined pipeline structure

I also had to change a couple of values in shared_config.json to get the s3 path to work correctly. I fear that Eric and I are in the midst of dueling fixes there and need to resolve them soon.