### PR TITLE
Root folder standardization + zero ACS population is null 

### DIFF
--- a/scripts/o3/o3_config.json
+++ b/scripts/o3/o3_config.json
@@ -16,7 +16,7 @@
           "outputs": {
             "raw_o3": {
               "type": "download",
-              "relative_path": "v1.2/downloads/2022/2022_ozone_daily_8hour_maximum.txt.gz",
+              "relative_path": "v{version}/downloads/2022/2022_ozone_daily_8hour_maximum.txt.gz",
               "source_url": "https://ofmpub.epa.gov/rsig/rsigserver?data/FAQSD/outputs/2022_ozone_daily_8hour_maximum.txt.gz",
               "notes": "Check for updates at: https://www.epa.gov/hesc/rsig-related-downloadable-data-files?#output"
             }
@@ -32,11 +32,11 @@
           "outputs": {
             "output_directory": {
               "type": "directory",
-              "relative_path": "v1.2/preprocessed_input/"
+              "relative_path": "v{version}/preprocessed_input/"
             },
             "main_tract_averages": {
               "type": "file",
-              "relative_path": "v1.2/preprocessed_input/o3_tract_annual_average.csv"
+              "relative_path": "v{version}/preprocessed_input/o3_tract_annual_average.csv"
             }
           }
         },
@@ -44,7 +44,7 @@
           "inputs": {
             "preprocessed_tracts": {
               "type": "file",
-              "relative_path": "v1.2/preprocessed_input/o3_tract_annual_average.csv"
+              "relative_path": "v{version}/preprocessed_input/o3_tract_annual_average.csv"
             },
             "weights": {
               "type": "shared_asset",
@@ -55,11 +55,11 @@
           "outputs": {
             "output_directory": {
               "type": "directory",
-              "relative_path": "v1.2/output/indicators/"
+              "relative_path": "v{version}/score_output/"
             },
             "indicator_output_template": {
               "type": "template",
-              "relative_path": "v1.2/output/indicators/{postal}/"
+              "relative_path": "v{version}/score_output/{postal}/"
             }
           }
         }
@@ -75,7 +75,7 @@
           "outputs": {
             "raw_o3": {
               "type": "download",
-              "relative_path": "v1.1/downloads/2021/2021_ozone_daily_8hour_maximum.txt.gz",
+              "relative_path": "v{version}/downloads/2021/2021_ozone_daily_8hour_maximum.txt.gz",
               "source_url": "https://ofmpub.epa.gov/rsig/rsigserver?data/FAQSD/outputs/2021_ozone_daily_8hour_maximum.txt.gz",
               "notes": "Check for updates at: https://www.epa.gov/hesc/rsig-related-downloadable-data-files?#output"
             }
@@ -91,11 +91,11 @@
           "outputs": {
             "output_directory": {
               "type": "directory",
-              "relative_path": "v1.1/preprocessed_input/"
+              "relative_path": "v{version}/preprocessed_input/"
             },
             "main_tract_averages": {
               "type": "file",
-              "relative_path": "v1.1/preprocessed_input/o3_tract_annual_average.csv"
+              "relative_path": "v{version}/preprocessed_input/o3_tract_annual_average.csv"
             }
           }
         },
@@ -103,7 +103,7 @@
           "inputs": {
             "preprocessed_tracts": {
               "type": "file",
-              "relative_path": "v1.1/preprocessed_input/o3_tract_annual_average.csv"
+              "relative_path": "v{version}/preprocessed_input/o3_tract_annual_average.csv"
             },
             "weights": {
               "type": "shared_asset",
@@ -114,11 +114,11 @@
           "outputs": {
             "output_directory": {
               "type": "directory",
-              "relative_path": "v1.1/output/indicators/"
+              "relative_path": "v{version}/score_output/"
             },
             "indicator_output_template": {
               "type": "template",
-              "relative_path": "v1.1/output/indicators/{postal}/"
+              "relative_path": "v{version}/score_output/{postal}/"
             }
           }
         }
@@ -134,7 +134,7 @@
           "outputs": {
             "raw_o3": {
               "type": "download",
-              "relative_path": "v1.0/downloads/2020/2020_ozone_daily_8hour_maximum.txt.gz",
+              "relative_path": "v{version}/downloads/2020/2020_ozone_daily_8hour_maximum.txt.gz",
               "source_url": "https://ofmpub.epa.gov/rsig/rsigserver?data/FAQSD/outputs/2020_ozone_daily_8hour_maximum.txt.gz",
               "notes": "Check for updates at: https://www.epa.gov/hesc/rsig-related-downloadable-data-files?#output"
             }
@@ -150,11 +150,11 @@
           "outputs": {
             "output_directory": {
               "type": "directory",
-              "relative_path": "v1.0/preprocessed_input/"
+              "relative_path": "v{version}/preprocessed_input/"
             },
             "main_tract_averages": {
               "type": "file",
-              "relative_path": "v1.0/preprocessed_input/o3_tract_annual_average.csv"
+              "relative_path": "v{version}/preprocessed_input/o3_tract_annual_average.csv"
             }
           }
         },
@@ -162,7 +162,7 @@
           "inputs": {
             "preprocessed_tracts": {
               "type": "file",
-              "relative_path": "v1.0/preprocessed_input/o3_tract_annual_average.csv"
+              "relative_path": "v{version}/preprocessed_input/o3_tract_annual_average.csv"
             },
             "weights": {
               "type": "shared_asset",
@@ -173,11 +173,11 @@
           "outputs": {
             "output_directory": {
               "type": "directory",
-              "relative_path": "v1.0/output/indicators/"
+              "relative_path": "v{version}/score_output/"
             },
             "indicator_output_template": {
               "type": "template",
-              "relative_path": "v1.0/output/indicators/{postal}/"
+              "relative_path": "v{version}/score_output/{postal}/"
             }
           }
         }
@@ -231,11 +231,11 @@
           "outputs": {
             "output_directory": {
               "type": "directory",
-              "relative_path": "v0.6/output/indicators/"
+              "relative_path": "v0.6/output/"
             },
             "indicator_output_template": {
               "type": "template",
-              "relative_path": "v0.6/output/indicators/{postal}/"
+              "relative_path": "v0.6/output/{postal}/"
             }
           }
         }
@@ -289,11 +289,11 @@
           "outputs": {
             "output_directory": {
               "type": "directory",
-              "relative_path": "v0.5/output/indicators/"
+              "relative_path": "v0.5/output/"
             },
             "indicator_output_template": {
               "type": "template",
-              "relative_path": "v0.5/output/indicators/{postal}/"
+              "relative_path": "v0.5/output/{postal}/"
             }
           }
         }

--- a/scripts/o3/o3_config.json
+++ b/scripts/o3/o3_config.json
@@ -1,5 +1,5 @@
 {
-  "local_root_path": "./pipeline/o3/",
+  "local_root_path": "pipeline/o3/",
   "remote_root_path": "s3://pedp-data-preserved/ejscreen-data-processing/pipeline/o3/",
   "download_settings": {
     "request_timeout_seconds": 120,

--- a/scripts/o3/o3_preprocess.py
+++ b/scripts/o3/o3_preprocess.py
@@ -2,36 +2,37 @@
 
 Purpose:
 	Read the raw national Ozone .txt.gz file directly, validate the tract-keyed
-	input columns, compute one annual average concentration per tract, and write
-	the tract-level intermediate CSV used by the indicator step.
+	input columns, compute one annual average of the ten highest daily 8-hour
+	maximum concentrations per tract, and write the tract-level intermediate CSV
+	used by the indicator step.
 
 Process summary:
 	- Resolve local or remote Ozone storage from the manifest + resolver.
 	- Validate the compressed file header before performing the full read.
 	- Read only the required columns from the raw source.
 	- Validate tract GEOIDs, dates, and numeric Ozone values.
-	- Aggregate to one annual average concentration per tract.
+	- Aggregate to the average of the ten highest daily 8-hour maximum values per tract.
 	- Write the tract-level CSV and log the output range.
 
 Runtime arguments (current defaults shown):
-		- storage_mode (positional): one of `local` or `remote`.
+		- -l/--location: required one of `local` or `remote` (assigned to internal `storage_mode`).
 		- -v/--version: optional config version to use. Default: `1.0`.
 		- --dry-run: long-only flag. When present the script validates the preprocess manifest
 			and source file headers, then exits without reading or writing full outputs.
 
 Outputs:
-		- v1.0/preprocessed_input/o3_tract_annual_average.csv under the active Ozone root (versioned by manifest).
+		- vn.m/preprocessed_input/o3_tract_annual_average.csv, version controlled by manifest.
 		- o3_preprocess.log in scripts/o3.
 
-Examples (run from the `scripts` folder):
+	Examples (run from the `scripts` folder):
 		- Dry-run (local):
-			python3 o3/o3_preprocess.py local --dry-run
+			python3 o3/o3_preprocess.py -l local --dry-run
 
 		- Full run (local, explicit version):
-			python3 o3/o3_preprocess.py local -v 1.0
+			python3 o3/o3_preprocess.py -l local -v 1.0
 
 		- Full run (remote):
-			python3 o3/o3_preprocess.py remote -v 1.0
+			python3 o3/o3_preprocess.py -l remote -v 1.0
 
 """
 
@@ -100,8 +101,10 @@ def get_config(argv=None) -> Config:
 		description='Read the raw national Ozone .txt.gz file, compute tract-level annual average concentration, and write the preprocessed tract CSV.'
 	)
 	parser.add_argument(
-		'storage_mode',
+		'-l', '--location',
+		dest='storage_mode',
 		choices=('local', 'remote'),
+		required=True,
 		help='Select whether the script reads and writes through the configured local root path or remote S3 root path.',
 	)
 	parser.add_argument(

--- a/scripts/o3/o3_preprocess.py
+++ b/scripts/o3/o3_preprocess.py
@@ -56,8 +56,10 @@ import sys
 REPO_ROOT = next((p for p in Path(__file__).resolve().parents if (p / ".git").exists()), None)
 if REPO_ROOT is None:
 	# This is a running-from-docker or other non-git environment cry for help.
+    # Undone: Handle non-git environments more gracefully when needed.
     raise RuntimeError("Architectural Error: Repository root anchor (.git) could not be found!")
-sys.path.insert(0, str(REPO_ROOT / "scripts"))
+SCRIPTS_ROOT = REPO_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_ROOT))
 
 import shared.build_manifest as build_manifest
 import shared.resolve_path as resolve_path

--- a/scripts/o3/o3_score.py
+++ b/scripts/o3/o3_score.py
@@ -69,8 +69,8 @@ if REPO_ROOT is None:
 	# This is a running-from-docker or other non-git environment cry for help.
     # Undone: Handle non-git environments more gracefully when needed.
     raise RuntimeError("Architectural Error: Repository root anchor (.git) could not be found!")
-SCRIPTS_ROOT = REPO_ROOT / "scripts"
-sys.path.insert(0, str(SCRIPTS_ROOT))
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
 
 import shared.build_manifest as build_manifest
 import shared.resolve_path as resolve_path

--- a/scripts/o3/o3_score.py
+++ b/scripts/o3/o3_score.py
@@ -67,8 +67,10 @@ import pandas as pd
 REPO_ROOT = next((p for p in Path(__file__).resolve().parents if (p / ".git").exists()), None)
 if REPO_ROOT is None:
 	# This is a running-from-docker or other non-git environment cry for help.
+    # Undone: Handle non-git environments more gracefully when needed.
     raise RuntimeError("Architectural Error: Repository root anchor (.git) could not be found!")
-sys.path.insert(0, str(REPO_ROOT / "scripts"))
+SCRIPTS_ROOT = REPO_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_ROOT))
 
 import shared.build_manifest as build_manifest
 import shared.resolve_path as resolve_path

--- a/scripts/o3/o3_score.py
+++ b/scripts/o3/o3_score.py
@@ -20,7 +20,7 @@ Process summary:
 
 Runtime arguments (current defaults shown):
 		- -l/--location: required one of `local` or `remote`.
-		- --state: required two-letter state code (e.g. `WY`) or `all` (case-insensitive) to process the full
+		- -s/--state: required two-letter state code (e.g. `WY`) or `all` (case-insensitive) to process the full
 			configured set. Use `--state all` to iterate across all configured states (the code maps this to
 			an internal `None` which `load_state_targets()` interprets as "all").
 		- --output-dir: optional explicit output directory (local path or S3 URI). Default: none (uses indicator output template).

--- a/scripts/o3/o3_score.py
+++ b/scripts/o3/o3_score.py
@@ -82,10 +82,16 @@ DEFAULT_FINAL_BG_SCORES_FILENAME = 'final_bg_scores.csv'
 TRACT_GEOID_COLUMN = 'tract_geoid'
 ANNUAL_AVERAGE_COLUMN = 'annual_average_ten_highest_MDA8'
 FINAL_SCORE_COLUMN = 'o3_score'  #Edit this to match EJAM/EJSCREEN e.g. o3
+
 # Column name defaults (lower_snake_case variables). Default to V1 names.
 # These are selected per-version at read time and then mapped to the canonical
 # names used throughout the downstream code.
-block_group_geoid_col = 'block_group_geoid_2022'
+# Note that the 2020, 2021, and 2022 raw o3 data files all use
+# the 2020 block_group_geoid values, not the block_group_geoid_2022 values
+# (which are only different for CT anyway). 
+block_group_geoid_col = 'block_group_geoid'
+# But, from version 1.0 onward, the population column that we use
+# for assigning nulls to zero-population block groups is the ACS 2022 population column.
 block_group_pop_col = 'acs_2022_bg_pop'
 state_abb_col = 'state_abb'
 
@@ -480,8 +486,9 @@ def process_state(cfg: Config, state_config: StateConfig, tract_scores: pd.DataF
 	bg_geoid_col = block_group_geoid_col
 	bg_pop_col = block_group_pop_col
 	if cfg.version_decimal is not None and cfg.version_decimal < Decimal('1.0'):
-		# Older manifests use the original column names
-		bg_geoid_col = 'block_group_geoid'
+		# Before version 1.0, we used the block_group_pop column for 
+		# determining null scores.
+		#bg_geoid_col = 'block_group_geoid'
 		bg_pop_col = 'block_group_pop'
 
 	usecols = [state_abb_col, bg_geoid_col, bg_pop_col]

--- a/scripts/shared/build_manifest.py
+++ b/scripts/shared/build_manifest.py
@@ -33,6 +33,7 @@ import sys
 REPO_ROOT = next((p for p in Path(__file__).resolve().parents if (p / ".git").exists()), None)
 if REPO_ROOT is None:
 	# This is a running-from-docker or other non-git environment cry for help.
+    # Undone: Handle non-git environments more gracefully when needed.
     raise RuntimeError("Architectural Error: Repository root anchor (.git) could not be found!")
 SCRIPTS_ROOT = REPO_ROOT / "scripts"
 sys.path.insert(0, str(SCRIPTS_ROOT))

--- a/scripts/shared/build_manifest.py
+++ b/scripts/shared/build_manifest.py
@@ -74,6 +74,7 @@ class _ManifestBuilder:
                     stage_block,
                     f"{name}.versions.{version}.stages.{stage}",
                     environment,
+                    version,
                 ),
             }
 
@@ -87,6 +88,7 @@ class _ManifestBuilder:
                 stage_block,
                 f"shared.assets.{name}.{version}.stages.{stage}",
                 environment,
+                version,
             ),
         }
         return manifest
@@ -137,6 +139,7 @@ class _ManifestBuilder:
                     entry_mapping,
                     field_prefix,
                     environment,
+                    version,
                 )
                 continue
 
@@ -150,10 +153,11 @@ class _ManifestBuilder:
         entry_mapping: dict[str, object],
         field_prefix: str,
         environment: str,
+        version: str,
     ) -> dict[str, str]:
         # Indicator inputs that reference local files/directories/templates
         # reuse the same relative entry compilation used for outputs.
-        return self._compile_relative_entry(config, entry_mapping, field_prefix, environment)
+        return self._compile_relative_entry(config, entry_mapping, field_prefix, environment, version)
 
     def _compile_shared_inputs(
         self,
@@ -179,6 +183,7 @@ class _ManifestBuilder:
         stage_block: dict[str, object],
         field_prefix: str,
         environment: str,
+        version: str,
     ) -> dict[str, dict[str, str]]:
         outputs = self._optional_mapping(stage_block.get("outputs"), "outputs")
         compiled: dict[str, dict[str, str]] = {}
@@ -191,6 +196,7 @@ class _ManifestBuilder:
                 entry_mapping,
                 output_prefix,
                 environment,
+                version,
             )
 
         return compiled
@@ -201,9 +207,11 @@ class _ManifestBuilder:
         entry_mapping: dict[str, object],
         field_prefix: str,
         environment: str,
+        version: str,
     ) -> dict[str, str]:
         root = self._get_root(config, environment, "target")
         relative = self._extract_relative_value(entry_mapping, field_prefix)
+        relative = resolve_path.substitute_version_placeholder(relative, version)
         compiled: dict[str, str] = {"root": root, "relative": relative}
 
         # Optionally copy fetch/source metadata when present (fetch outputs

--- a/scripts/shared/fetch_raw.py
+++ b/scripts/shared/fetch_raw.py
@@ -5,29 +5,45 @@ Purpose:
     scores. It depends on the stage-based indicator and shared config .json files
     to specify fetch outputs, source locations, and destination paths.
 
-Usage examples:
+Process summary:
+    - Resolve the indicator or shared config, stage manifest, and canonical local/remote
+        root paths for the requested target.
+    - Validate `--state` (or expand the source/destination templates for every configured
+        state when `--state all` is requested).
+    - Skip the download if the destination file already exists.
+    - Stream the source URL to the destination, logging heartbeat progress periodically.
+    - Append one row per attempted download to fetch_audit.csv.
+    - Print and log a run summary (succeeded/failed/skipped counts).
 
-    # Simple indicator with a default download
-    python shared/fetch_raw.py --indicator pm25 --storage-mode local
+Runtime arguments (current defaults shown):
+    - -i/--indicator: required. Indicator key such as `pm25`, `o3`, or `shared`.
+    - -l/--location: required one of `local` or `remote`.
+    - -d/--download: optional fetch-stage output key. Required when the selected target has
+        multiple fetch outputs, and always required for shared fetches.
+    - -v/--version: optional; required only when the selected target has more than one
+        configured version.
+    - -s/--state: optional two-letter postal code (e.g. `VT`) for state-scoped downloads.
+        Validated against `scripts/shared/state_config.json` and translated to the FIPS code
+        used in filenames and URLs. The postal code (uppercased) is stored in the audit. The
+        special value `all` (case-insensitive) iterates across all configured states.
+    - --dry-run: long-only flag. Prints the expanded source URL and destination path without
+        downloading.
 
-    # Remote fetch for ozone
-    python shared/fetch_raw.py --indicator o3 --storage-mode remote
+Outputs:
+    - The downloaded raw file at the resolved local path or S3 URI.
+    - One appended row per attempted download in fetch_audit.csv (scripts/shared), recording
+        run id, timing, status (`uploaded`/`skipped`/`failed`), and bytes downloaded.
+    - fetch_raw.log in scripts/shared.
 
-    # Shared tiger BG download for Vermont (postal code). --state uses two-letter postal codes.
-    python shared/fetch_raw.py --indicator shared --download tiger_bg_2020 --state VT --storage-mode local
+Examples (run from the `scripts` folder):
+    - Simple indicator with a default download:
+        python3 shared/fetch_raw.py --indicator pm25 -l local
 
-Notes:
-    - `--storage-mode`/`-l` is required and must be either `local` or `remote`.
-    - `--download` selects a fetch-stage output key. It is required when the selected target has
-        multiple fetch outputs, and for shared fetches.
-    - `--version` is optional only when the selected target has exactly one configured version.
-    - `--state`
-        - For state-scoped downloads use `--state` with a two-letter postal code which will be
-            validated against `scripts/shared/state_config.json` and translated to the FIPS code
-            used in filenames and URLs. The postal code (uppercased) is stored in the audit.
-        - The special value `all` is supported for `--state` (case-insensitive) to iterate across
-            all configured states.
-    - Use `--dry-run` to print the expanded source URL and destination path without downloading.
+    - Remote fetch for ozone:
+        python3 shared/fetch_raw.py --indicator o3 -l remote
+
+    - Shared tiger BG download for Vermont (postal code). --state uses two-letter postal codes:
+        python3 shared/fetch_raw.py --indicator shared --download tiger_bg_2020 --state VT -l local
 """
 
 from __future__ import annotations
@@ -274,7 +290,7 @@ def get_config(argv=None) -> Config:
     parser = argparse.ArgumentParser(description='Centralized raw data fetch utility.')
     # Required arguments (listed first)
     parser.add_argument('-i', '--indicator', required=True, help='Required: Indicator key such as pm25 or shared')
-    parser.add_argument('-l', '--location', '--storage-mode', dest='storage_mode', choices=('local', 'remote'), required=True, help='Required: Select storage location (local or remote)')
+    parser.add_argument('-l', '--location', dest='storage_mode', choices=('local', 'remote'), required=True, help='Required: Select storage location (local or remote)')
 
     # Optional arguments
     parser.add_argument('-d', '--download', help='Optional: Fetch-stage output key from the stage-based config')

--- a/scripts/shared/fetch_raw.py
+++ b/scripts/shared/fetch_raw.py
@@ -56,13 +56,11 @@ import requests
 REPO_ROOT = next((p for p in Path(__file__).resolve().parents if (p / ".git").exists()), None)
 if REPO_ROOT is None:
 	# This is a running-from-docker or other non-git environment cry for help.
+    # Undone: Handle non-git environments more gracefully when needed.
     raise RuntimeError("Architectural Error: Repository root anchor (.git) could not be found!")
-sys.path.insert(0, str(REPO_ROOT / "scripts"))
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
 
-import shared.build_manifest as build_manifest
-import shared.resolve_path as resolve_path
-
-SCRIPTS_DIR = Path(__file__).resolve().parent
 PROCESS_NAME = 'fetch_raw'
 DEFAULT_LOG_FILENAME = 'fetch_raw.log'
 DEFAULT_AUDIT_FILENAME = 'fetch_audit.csv'

--- a/scripts/shared/fetch_raw.py
+++ b/scripts/shared/fetch_raw.py
@@ -59,7 +59,12 @@ if REPO_ROOT is None:
     # Undone: Handle non-git environments more gracefully when needed.
     raise RuntimeError("Architectural Error: Repository root anchor (.git) could not be found!")
 SCRIPTS_DIR = REPO_ROOT / "scripts"
+logging.info("REPO_ROOT: %s", REPO_ROOT)
+logging.info("SCRIPTS_DIR: %s", SCRIPTS_DIR)
 sys.path.insert(0, str(SCRIPTS_DIR))
+
+import shared.build_manifest as build_manifest
+import shared.resolve_path as resolve_path
 
 PROCESS_NAME = 'fetch_raw'
 DEFAULT_LOG_FILENAME = 'fetch_raw.log'
@@ -278,9 +283,7 @@ def get_config(argv=None) -> Config:
     parser.add_argument('--dry-run', action='store_true', help='Optional: Print expanded source URL and destination path and exit')
  
     args = parser.parse_args(argv)
-
     indicator = args.indicator
-    scripts_root = SCRIPTS_DIR.parent
 
     # If the user provided a --state value, validate it early and obtain the
     # canonical postal and fips values from the shared state config. Support
@@ -337,7 +340,7 @@ def get_config(argv=None) -> Config:
         local_root = resolve_path.get_shared_root(asset_name, version, 'local')
         remote_root = resolve_path.get_shared_root(asset_name, version, 'remote')
     else:
-        indicator_config = _load_json_object(scripts_root / indicator / f'{indicator}_config.json', f'indicator {indicator}')
+        indicator_config = _load_json_object(SCRIPTS_DIR / indicator / f'{indicator}_config.json', f'indicator {indicator}')
         versions = _require_mapping(indicator_config.get('versions'), f'{indicator}.versions')
         version = _resolve_version(versions, f'indicator {indicator}', args.version)
         request_timeout_seconds, chunk_size_bytes = _get_download_settings(indicator_config, indicator)
@@ -814,6 +817,8 @@ def main(argv=None) -> int:
 
 
 if __name__ == '__main__':
+    logging.info("Starting fetch_raw script")
+    logging.info("SCRIPTS_DIR: %s", SCRIPTS_DIR)
     try:
         raise SystemExit(main())
     except FileNotFoundError as exc:

--- a/scripts/shared/resolve_path.py
+++ b/scripts/shared/resolve_path.py
@@ -7,6 +7,7 @@ Public (flat) module-level functions:
 - get_indicator_root(indicator: str, version: str, environment: str = "local") -> str
 - get_shared_root(asset: str, version: str, environment: str = "local") -> str
 - get_shared_version_block(config: dict, asset_name: str, version: str) -> dict
+- substitute_version_placeholder(template: str, version: str) -> str
 
 Return contract:
 - Functions that resolve locations return a dictionary containing at least the keys
@@ -47,6 +48,18 @@ VALID_ENVIRONMENTS = {"local", "remote"}
 VALID_SHARED_CATEGORIES = {"downloads", "preprocessed_input"}
 
 
+def substitute_version_placeholder(template: str, version: str) -> str:
+    """Replace a literal `{version}` placeholder with the resolved version string.
+
+    This lets config authors write version-scoped relative paths (e.g.
+    `v{version}/downloads/...`) that automatically track the `versions`/`assets.*`
+    dict key instead of requiring a manually maintained duplicate field. Other
+    unresolved placeholders (e.g. `{postal}`, `{fips}`) are left intact for
+    later substitution by the caller.
+    """
+    return template.replace("{version}", version)
+
+
 class _PathResolver:
     def __init__(self) -> None:
         self._indicator_config_cache: dict[str, dict[str, object]] = {}
@@ -75,6 +88,7 @@ class _PathResolver:
             asset.get("relative_path"),
             f"{indicator}.versions.{version}.stages.fetch.outputs.{asset_key}.relative_path",
         )
+        relative = substitute_version_placeholder(relative, version)
         root = self._get_root(config, environment, f"indicator {indicator}")
         return {"root": root, "relative": relative}
 
@@ -123,6 +137,7 @@ class _PathResolver:
                 preprocess_asset.get("relative_path_template"),
                 f"shared.assets.{asset}.{version}.stages.preprocess.outputs.{asset}.relative_path_template",
             )
+            relative = substitute_version_placeholder(relative, version)
         else:
             if not asset_key:
                 self._fail(
@@ -141,6 +156,7 @@ class _PathResolver:
                 download_asset.get("relative_path_template"),
                 f"shared.assets.{asset}.{version}.stages.fetch.outputs.{asset_key}.relative_path_template",
             )
+            relative = substitute_version_placeholder(relative, version)
 
         root = self._get_root(config, environment, "shared")
         return {"root": root, "relative": relative}

--- a/scripts/shared/resolve_path.py
+++ b/scripts/shared/resolve_path.py
@@ -29,11 +29,19 @@ import json
 import logging
 from pathlib import Path
 
+# For any local paths that we need to resolve, we want them to
+# consistently be resolved relative to the project root, no matter 
+# where this code is executed from.
+REPO_ROOT = next((p for p in Path(__file__).resolve().parents if (p / ".git").exists()), None)
+if REPO_ROOT is None:
+	# This is a running-from-docker or other non-git environment cry for help.
+    # Undone: Handle non-git environments more gracefully when needed.
+    raise RuntimeError("Architectural Error: Repository root anchor (.git) could not be found!")
+SCRIPTS_ROOT = REPO_ROOT / "scripts"
 
 LOGGER = logging.getLogger(__name__)
 LOGGER.addHandler(logging.NullHandler())
 
-SCRIPTS_ROOT = Path(__file__).resolve().parent.parent
 SHARED_CONFIG_PATH = Path(__file__).with_name("shared_config.json")
 VALID_ENVIRONMENTS = {"local", "remote"}
 VALID_SHARED_CATEGORIES = {"downloads", "preprocessed_input"}
@@ -266,9 +274,7 @@ def get_indicator_root(indicator: str, version: str, environment: str = "local")
     _ = resolver._get_indicator_version_block(config, indicator, version)
     root = resolver._get_root(config, environment, f"indicator {indicator}")
     if environment == "local":
-        # Resolve relative local roots against the project root (scripts parent)
-        project_root = SCRIPTS_ROOT.parent
-        return str((project_root / root).resolve())
+        return str((REPO_ROOT / root).resolve())
     return root
 
 
@@ -285,8 +291,7 @@ def get_shared_root(asset: str, version: str, environment: str = "local") -> str
     _ = resolver._get_shared_version_block(config, asset, version)
     root = resolver._get_root(config, environment, "shared")
     if environment == "local":
-        project_root = SCRIPTS_ROOT.parent
-        return str((project_root / root).resolve())
+        return str((REPO_ROOT / root).resolve())
     return root
 
 

--- a/scripts/shared/resolve_path.py
+++ b/scripts/shared/resolve_path.py
@@ -146,6 +146,7 @@ class _PathResolver:
         return {"root": root, "relative": relative}
 
     def _load_indicator_config(self, indicator: str) -> dict[str, object]:
+        logging.info("Loading indicator config for %s, SCRIPTS_ROOT: %s", indicator, SCRIPTS_ROOT)
         if indicator in self._indicator_config_cache:
             return self._indicator_config_cache[indicator]
 

--- a/scripts/utilities/validation/compareScores.py
+++ b/scripts/utilities/validation/compareScores.py
@@ -62,8 +62,6 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-import math
-
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
@@ -72,6 +70,19 @@ import geopandas as gpd
 from matplotlib.cm import ScalarMappable
 from matplotlib.colors import Normalize, TwoSlopeNorm
 
+# All of our project-specific imports must be relative to the 
+# `scripts` folder which we assume is at the first level of the
+# repository. 
+# NB: ***If `scripts` moves, this code will have to change.***
+# Walk up our current working directory tree until you find the
+# repository root, then add the scripts directory to sys.path
+REPO_ROOT = next((p for p in Path(__file__).resolve().parents if (p / ".git").exists()), None)
+if REPO_ROOT is None:
+	# This is a running-from-docker or other non-git environment cry for help.
+    # Undone: Handle non-git environments more gracefully when needed.
+    raise RuntimeError("Architectural Error: Repository root anchor (.git) could not be found!")
+SCRIPTS_ROOT = REPO_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_ROOT))
 
 REQUIRED_FIELDS = (
     'indicator',

--- a/scripts/validate_o3_workflow.sh
+++ b/scripts/validate_o3_workflow.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Validate O3 workflow: fetch raw -> preprocess -> score
+# Run this from the repository `scripts/` folder or execute directly from the project root.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR" || exit 1
+
+PYTHON=${PYTHON:-python3}
+
+echo "Using Python interpreter: $PYTHON"
+
+fail() {
+  rc=$1
+  shift
+  echo "ERROR: $* (exit $rc)" >&2
+  exit $rc
+}
+
+echo "[1/3] Fetching raw O3 data (indicator=o3, version=1.0, storage=local)"
+$PYTHON shared/fetch_raw.py --indicator o3 --location local --version 1.0 || fail $? "fetch_raw failed"
+
+echo "[2/3] Running o3_preprocess (storage=local, version=1.0)"
+$PYTHON o3/o3_preprocess.py local -v 1.0 || fail $? "o3_preprocess failed"
+
+echo "[3/3] Running o3_score (storage=local, version=1.0) for a small number of states -- not CT!!"
+$PYTHON o3/o3_score.py --location local --state MT -v 1.0 || fail $? "o3_score failed"
+$PYTHON o3/o3_score.py --location local --state NJ -v 1.0 || fail $? "o3_score failed"
+$PYTHON o3/o3_score.py --location local --state RI -v 1.0 || fail $? "o3_score failed"
+$PYTHON o3/o3_score.py --location local --state WY -v 1.0 || fail $? "o3_score failed"
+
+# Note: the following commandline is expected to fail due to NAs in the group block weights data for CT
+# $PYTHON o3/o3_score.py --location local --state CT -v 1.0 || echo "Expected failure for CT due to NAs in block weights"
+
+echo "O3 validation workflow completed successfully. No comparisons were run"


### PR DESCRIPTION
I was working on a new branch as I made some changes to standardize module behavior including:
- how we determine the root folder to use as the base for our pipeline
- how we include python modules when they are not in the current folder with the including code
- runtime argument syntax

Then, after Friday's work session with @EmmaLiTsai and @victoriagonzalez6, I applied our agreed-upon adjustment to the code that generates null (not zero) scores for any blocks in block groups with **ACS** zero populations.

That means that the O3 code and configurations to generate scores using 2020 (EJAM original), 2021, and 2022 raw data should be ready for prime time. So I'm merging this branch into `dataVersioning`.

I'm going to create the pull request and then approve it. I considered doing this merge locally but decided I should do it here to  make it more visible to others.